### PR TITLE
chore: rename to second-brain-mcp + Foam compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Obsidian MCP Second Brain Server
+# Second Brain MCP Server
 
 A read-only MCP server for intelligent, secure access to your Obsidian vault—enabling semantic search, metadata filtering, and more for LLMs.
 
@@ -38,7 +38,7 @@ This server works with **any directory of Markdown files** — not just Obsidian
 Point `--vault-path` at your Foam workspace root. No configuration changes needed:
 
 ```bash
-npx -y @comfucios/obsidian-mcp-sb --vault-path "/path/to/your/foam-workspace"
+npx -y @comfucios/second-brain-mcp --vault-path "/path/to/your/foam-workspace"
 ```
 
 Foam features that work out of the box:
@@ -70,30 +70,30 @@ For write operations, consider using dedicated Obsidian plugins with built-in sa
 ### One-Click Installation
 
 - **VS Code:**
-  [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Obsidian_MCP_SB-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=obsidian-mcp-sb&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40comfucios%2Fobsidian-mcp-sb%22%5D%7D)
+  [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Second_Brain_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=second-brain-mcp&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40comfucios%2Fsecond-brain-mcp%22%5D%7D)
 - **VS Code Insiders:**
-  [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Obsidian_MCP_SB-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=obsidian-mcp-sb&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40comfucios%2Fobsidian-mcp-sb%22%5D%7D)
+  [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Second_Brain_MCP-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=second-brain-mcp&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40comfucios%2Fsecond-brain-mcp%22%5D%7D)
 - **Cursor:**
-  [![Install in Cursor](https://img.shields.io/badge/Cursor-Install_Obsidian_MCP_SB-00D8FF?style=flat-square&logo=cursor&logoColor=white)](https://cursor.com/en/install-mcp?name=obsidian-mcp-sb&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoibnB4IC15IEBjb21mdWNpb3Mvb2JzaWRpYW4tbWNwLXNiIiwiZW52Ijp7fX0=)
+  [![Install in Cursor](https://img.shields.io/badge/Cursor-Install_Second_Brain_MCP-00D8FF?style=flat-square&logo=cursor&logoColor=white)](https://cursor.com/en/install-mcp?name=second-brain-mcp&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoibnB4IC15IEBjb21mdWNpb3Mvc2Vjb25kLWJyYWluLW1jcCIsImVudiI6e319)
 
 ### Manual Installation
 
 No installation needed! Use directly with npx:
 
 ```bash
-npx -y @comfucios/obsidian-mcp-sb --vault-path "/path/to/your/vault"
+npx -y @comfucios/second-brain-mcp --vault-path "/path/to/your/vault"
 ```
 
 #### Local Development
 
 ```bash
-cd obsidian-mcp-sb
+cd second-brain-mcp
 npm install
 npm run build
 npm link
 ```
 
-This makes the server available globally as `obsidian-mcp-sb`.
+This makes the server available globally as `second-brain-mcp`.
 
 ### Claude Code & Claude Desktop
 
@@ -102,7 +102,7 @@ This makes the server available globally as `obsidian-mcp-sb`.
 Add the server using:
 
 ```bash
-claude mcp add obsidian-sb -- npx -y @comfucios/obsidian-mcp-sb --vault-path "/path/to/your/vault"
+claude mcp add second-brain -- npx -y @comfucios/second-brain-mcp --vault-path "/path/to/your/vault"
 ```
 
 #### Claude Desktop
@@ -115,11 +115,11 @@ Add to your Claude Desktop configuration file:
 ```json
 {
   "mcpServers": {
-    "obsidian-sb": {
+    "second-brain": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path",
         "/path/to/your/vault"
       ]
@@ -144,11 +144,11 @@ Add to your MCP configuration file.
 ```json
 {
   "mcpServers": {
-    "obsidian-sb": {
+    "second-brain": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path",
         "/Users/ioanniskarasavvaidis/Documents/Obsidian Vault"
       ]
@@ -164,20 +164,20 @@ You can configure multiple vault instances:
 ```json
 {
   "mcpServers": {
-    "obsidian-personal": {
+    "second-brain-personal": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path",
         "/Users/username/Documents/Personal Vault"
       ]
     },
-    "obsidian-work": {
+    "second-brain-work": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path",
         "/Users/username/Documents/Work Vault"
       ]
@@ -193,8 +193,8 @@ If you're developing locally with `npm link`:
 ```json
 {
   "mcpServers": {
-    "obsidian-sb": {
-      "command": "obsidian-mcp-sb",
+    "second-brain": {
+      "command": "second-brain-mcp",
       "args": ["--vault-path", "/path/to/your/vault"]
     }
   }
@@ -226,7 +226,7 @@ See [docs/README.md](docs/README.md) for:
 Run the server instantly with npx (no install required):
 
 ```bash
-npx -y @comfucios/obsidian-mcp-sb --vault-path "/path/to/your/vault"
+npx -y @comfucios/second-brain-mcp --vault-path "/path/to/your/vault"
 ```
 
 Or add to Claude Code/Claude Desktop (see Configuration & Installation below).
@@ -249,7 +249,7 @@ See [docs/contributing.md](docs/contributing.md) for contribution guidelines.
 
 The server uses **SQLite database storage by default** for efficient indexing and persistent caching:
 
-- **Database Mode (Default)**: Stores indexed notes in `.obsidian-mcp/notes.db` within your vault
+- **Database Mode (Default)**: Stores indexed notes in `.second-brain-mcp/notes.db` within your vault
   - Persistent indexing (survives server restarts)
   - Efficient for large vaults (1000+ notes)
   - Full-text search with SQLite FTS5
@@ -282,7 +282,7 @@ See [docs/dependencies.md](docs/dependencies.md) for a full list of production a
 
 ## Support
 
-If obsidian-mcp-sb saves you time, consider [sponsoring me on GitHub](https://github.com/sponsors/comfucios) or [buy me a coffee](https://www.buymeacoffee.com/comfucios).
+If second-brain-mcp saves you time, consider [sponsoring me on GitHub](https://github.com/sponsors/comfucios) or [buy me a coffee](https://www.buymeacoffee.com/comfucios).
 
 ## License
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -14,11 +14,11 @@ No installation needed! Just configure Claude Code:
    ```json
    {
      "mcpServers": {
-       "obsidian-sb": {
+       "second-brain": {
          "command": "npx",
          "args": [
            "-y",
-           "@comfucios/obsidian-mcp-sb",
+           "@comfucios/second-brain-mcp",
            "--vault-path",
            "/Users/ioanniskarasavvaidis/Documents/Obsidian Vault"
          ]
@@ -40,20 +40,20 @@ You can configure multiple vaults by adding multiple server entries:
 ```json
 {
   "mcpServers": {
-    "obsidian-personal": {
+    "second-brain-personal": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path",
         "/Users/username/Documents/Personal Vault"
       ]
     },
-    "obsidian-work": {
+    "second-brain-work": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path",
         "/Users/username/Documents/Work Vault"
       ]
@@ -69,7 +69,7 @@ For development or customization:
 1. **Install dependencies**
 
    ```bash
-   cd obsidian-mcp-sb
+   cd second-brain-mcp
    npm install
    ```
 
@@ -90,8 +90,8 @@ For development or customization:
    ```json
    {
      "mcpServers": {
-       "obsidian-sb": {
-         "command": "obsidian-mcp-sb",
+       "second-brain": {
+         "command": "second-brain-mcp",
          "args": ["--vault-path", "/path/to/your/vault"]
        }
      }
@@ -105,7 +105,7 @@ For development or customization:
 You can test the server directly using stdio:
 
 ```bash
-cd obsidian-mcp-sb
+cd second-brain-mcp
 npm start
 ```
 
@@ -169,11 +169,11 @@ All configuration can be done via CLI arguments in your `mcp.json` file. No need
 ```json
 {
   "mcpServers": {
-    "obsidian-sb": {
+    "second-brain": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path", "/Users/username/Documents/Vault",
         "--index-patterns", "Work/**/*.md,Projects/**/*.md,Archive/**/*.md",
         "--exclude-patterns", ".trash/**,node_modules/**",
@@ -189,7 +189,7 @@ All configuration can be done via CLI arguments in your `mcp.json` file. No need
 
 **For large vaults (1000+ notes):**
 - Use database mode (default) for efficient indexing and lower memory usage
-- Database is stored in `.obsidian-mcp/notes.db` within your vault
+- Database is stored in `.second-brain-mcp/notes.db` within your vault
 - Indexing persists across server restarts (no re-indexing needed)
 - Decrease `--max-search-results` for faster searches if needed
 - Use more specific `--index-patterns` to limit indexed notes
@@ -210,11 +210,11 @@ Use the `--index-patterns` argument:
 ```json
 {
   "mcpServers": {
-    "obsidian-sb": {
+    "second-brain": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path", "/path/to/vault",
         "--index-patterns", "Work/**/*.md,Projects/**/*.md,CustomFolder/**/*.md"
       ]
@@ -230,11 +230,11 @@ Use the `--exclude-patterns` argument:
 ```json
 {
   "mcpServers": {
-    "obsidian-sb": {
+    "second-brain": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path", "/path/to/vault",
         "--exclude-patterns", "Archive/**/*.md,_Meta/**,.trash/**,Private/**/*.md"
       ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation Overview
 
-Welcome! This folder contains detailed guides and references for all aspects of the Obsidian MCP Second Brain Server.
+Welcome! This folder contains detailed guides and references for all aspects of the Second Brain MCP Server.
 
 **How to use this documentation:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,16 +8,16 @@ This diagram shows the high-level system architecture and data flow for the MCP 
 ````mermaid
 graph TD
     A[MCP Client<br/>Claude/VSCode] -->|MCP Protocol| B[MCP Server<br/>index.ts]
-    B -->|Initialize| C[ObsidianVault<br/>vault.ts]
+    B -->|Initialize| C[MarkdownVault<br/>vault.ts]
     C -->|Create Storage| D{Storage Factory<br/>storage-factory.ts}
 
     D -->|Default| E[DatabaseStorage<br/>database-storage.ts]
     D -->|--use-memory| F[MemoryStorage<br/>memory-storage.ts]
 
-    E -->|Stores in| G[(SQLite DB<br/>.obsidian-mcp/notes.db)]
+    E -->|Stores in| G[(SQLite DB<br/>.second-brain-mcp/notes.db)]
     F -->|Stores in| H[In-Memory<br/>Map + Fuse.js]
 
-    C -->|Scan Files| I[Obsidian Vault<br/>*.md files]
+    C -->|Scan Files| I[Markdown Vault<br/>*.md files]
     I -->|Parse Frontmatter| J[gray-matter]
     J -->|Index Notes| E
     J -->|Index Notes| F

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,11 +57,11 @@ The server automatically detects your vault structure based on the standardized 
 ```json
 {
   "mcpServers": {
-    "obsidian-sb": {
+    "second-brain": {
       "command": "npx",
       "args": [
         "-y",
-        "@comfucios/obsidian-mcp-sb",
+        "@comfucios/second-brain-mcp",
         "--vault-path",
         "/Users/username/Documents/Vault",
         "--index-patterns",

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,7 +41,7 @@ npm run lint:fix
 
 The server uses **SQLite database storage by default** for efficient indexing and persistent caching:
 
-- **Database Mode (Default):** Stores indexed notes in `.obsidian-mcp/notes.db` within your vault
+- **Database Mode (Default):** Stores indexed notes in `.second-brain-mcp/notes.db` within your vault
   - Persistent indexing (survives server restarts)
   - Efficient for large vaults (1000+ notes)
   - Full-text search with SQLite FTS5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@comfucios/obsidian-mcp-sb",
-  "version": "0.1.7",
+  "name": "@comfucios/second-brain-mcp",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@comfucios/obsidian-mcp-sb",
-      "version": "0.1.7",
+      "name": "@comfucios/second-brain-mcp",
+      "version": "0.1.6",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -17,7 +17,7 @@
         "gray-matter": "^4.0.3"
       },
       "bin": {
-        "obsidian-mcp-sb": "dist/index.js"
+        "second-brain-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "@comfucios/obsidian-mcp-sb",
-  "version": "0.1.7",
-  "description": "MCP server for Obsidian vault as a second brain",
+  "name": "@comfucios/second-brain-mcp",
+  "version": "0.1.6",
+  "description": "MCP server for any Markdown vault as a second brain (Obsidian, Foam, Logseq, plain files)",
   "main": "dist/index.js",
   "author": "Ioannis Karasavvaidis <ioannis@studio110.eu>",
   "license": "ISC",
   "type": "module",
   "repository": {
-    "url": "https://github.com/CoMfUcIoS/obsidian-mcp-sb"
+    "url": "https://github.com/CoMfUcIoS/second-brain-mcp"
   },
   "bugs": {
-    "url": "https://github.com/CoMfUcIoS/obsidian-mcp-sb/issues"
+    "url": "https://github.com/CoMfUcIoS/second-brain-mcp/issues"
   },
-  "homepage": "https://github.com/CoMfUcIoS/obsidian-mcp-sb#readme",
+  "homepage": "https://github.com/CoMfUcIoS/second-brain-mcp#readme",
   "bin": {
-    "obsidian-mcp-sb": "dist/index.js"
+    "second-brain-mcp": "dist/index.js"
   },
   "scripts": {
     "build": "tsc",

--- a/src/__tests__/database-storage.test.ts
+++ b/src/__tests__/database-storage.test.ts
@@ -24,12 +24,12 @@ describe('DatabaseStorage', () => {
 
   describe('Initialization', () => {
     test('creates database directory if not exists', async () => {
-      const dbDir = join(testVaultPath, '.obsidian-mcp');
+      const dbDir = join(testVaultPath, '.second-brain-mcp');
       expect(existsSync(dbDir)).toBe(true);
     });
 
     test('creates database file', async () => {
-      const dbPath = join(testVaultPath, '.obsidian-mcp', 'notes.db');
+      const dbPath = join(testVaultPath, '.second-brain-mcp', 'notes.db');
       expect(existsSync(dbPath)).toBe(true);
     });
 

--- a/src/__tests__/foam-compatibility.test.ts
+++ b/src/__tests__/foam-compatibility.test.ts
@@ -14,7 +14,7 @@
  *   - .vscode/ and other non-md artifacts ignored
  *   - no .obsidian/ folder present
  */
-import { ObsidianVault } from "../vault.js";
+import { MarkdownVault } from "../vault.js";
 import { VaultConfig } from "../types.js";
 import { mkdir, writeFile, rm } from "fs/promises";
 import { join } from "path";
@@ -22,7 +22,7 @@ import { tmpdir } from "os";
 
 describe("Foam Compatibility", () => {
   let workspacePath: string;
-  let vault: ObsidianVault;
+  let vault: MarkdownVault;
   let config: VaultConfig;
 
   async function retryUntilFound<T>(
@@ -67,7 +67,7 @@ describe("Foam Compatibility", () => {
       },
     };
 
-    vault = new ObsidianVault(config);
+    vault = new MarkdownVault(config);
   });
 
   afterEach(async () => {

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -2,12 +2,12 @@ import { describe, test, expect, beforeAll, afterAll } from "@jest/globals";
 import { mkdir, writeFile, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
-import { ObsidianVault } from "../vault.js";
+import { MarkdownVault } from "../vault.js";
 import { VaultConfig } from "../types.js";
 
 describe("Integration Tests - Full Workflow", () => {
   let testVaultPath: string;
-  let vault: ObsidianVault;
+  let vault: MarkdownVault;
   let config: VaultConfig;
 
   beforeAll(async () => {
@@ -89,7 +89,7 @@ Completed personal task.`,
       },
     };
 
-    vault = new ObsidianVault(config);
+    vault = new MarkdownVault(config);
     await vault.initialize();
   }, 15000);
 
@@ -314,7 +314,7 @@ Puppet-related task.`,
       );
 
       // Reinitialize vault to pick up new note
-      vault = new ObsidianVault(config);
+      vault = new MarkdownVault(config);
       await vault.initialize();
 
       // Parent tag should match child

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -1,11 +1,11 @@
 /* global setTimeout */
-import { ObsidianVault } from "../vault.js";
+import { MarkdownVault } from "../vault.js";
 import { VaultConfig } from "../types.js";
 import { mkdir, writeFile, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 
-describe("ObsidianVault", () => {
+describe("MarkdownVault", () => {
   // Helper to retry a query until expected results are found or timeout.
   // Re-runs vault.initialize() on each retry so a partial scan from a
   // loaded CI runner doesn't permanently poison the in-memory store.
@@ -25,7 +25,7 @@ describe("ObsidianVault", () => {
     return results;
   }
   let testVaultPath: string;
-  let vault: ObsidianVault;
+  let vault: MarkdownVault;
   let config: VaultConfig;
 
   beforeEach(async () => {
@@ -53,7 +53,7 @@ describe("ObsidianVault", () => {
       },
     };
 
-    vault = new ObsidianVault(config);
+    vault = new MarkdownVault(config);
   });
 
   afterEach(async () => {
@@ -144,7 +144,7 @@ describe("ObsidianVault", () => {
     test("skips files exceeding max size", async () => {
       // Create a large file (> 10MB mock)
       const largeConfig = { ...config, maxFileSize: 100 }; // 100 bytes for testing
-      vault = new ObsidianVault(largeConfig);
+      vault = new MarkdownVault(largeConfig);
 
       const largeContent = "x".repeat(200); // 200 bytes
       await writeFile(
@@ -432,7 +432,7 @@ describe("ObsidianVault", () => {
         ...config,
         excludePatterns: [], // Don't exclude Archive at index time
       };
-      vault = new ObsidianVault(configWithArchive);
+      vault = new MarkdownVault(configWithArchive);
 
       await writeFile(
         join(testVaultPath, "Archive", "archived.md"),
@@ -456,7 +456,7 @@ describe("ObsidianVault", () => {
         indexPatterns: ["**/*.md"],
       };
 
-      const invalidVault = new ObsidianVault(invalidConfig);
+      const invalidVault = new MarkdownVault(invalidConfig);
 
       // Should initialize without error but find no notes
       await invalidVault.initialize();
@@ -475,7 +475,7 @@ describe("ObsidianVault", () => {
         indexPatterns: ["**/*.md"],
       };
 
-      const emptyVault = new ObsidianVault(emptyConfig);
+      const emptyVault = new MarkdownVault(emptyConfig);
 
       // Should not throw but should log warning
       await emptyVault.initialize();

--- a/src/database-storage.ts
+++ b/src/database-storage.ts
@@ -13,8 +13,8 @@ export class DatabaseStorage implements IStorage {
   private readonly dbPath: string;
 
   constructor(vaultPath: string) {
-    // Store database in vault's .obsidian-mcp directory
-    const dbDir = join(vaultPath, '.obsidian-mcp');
+    // Store database in vault's .second-brain-mcp directory
+    const dbDir = join(vaultPath, '.second-brain-mcp');
     if (!existsSync(dbDir)) {
       mkdirSync(dbDir, { recursive: true });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   ListToolsRequestSchema,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
-import { ObsidianVault } from "./vault.js";
+import { MarkdownVault } from "./vault.js";
 import { defaultConfig } from "./config.js";
 import {
   SearchOptions,
@@ -117,7 +117,7 @@ if (!vaultPath) {
   console.error(
     "Error: Vault path is required. Please provide --vault-path argument.",
   );
-  console.error('Example: obsidian-mcp-sb --vault-path "/path/to/vault"');
+  console.error('Example: second-brain-mcp --vault-path "/path/to/vault"');
   process.exit(1);
 }
 
@@ -178,7 +178,7 @@ const vaultConfig: VaultConfig = {
 // Validate configuration
 validateConfig(vaultConfig);
 
-const vault = new ObsidianVault(vaultConfig);
+const vault = new MarkdownVault(vaultConfig);
 
 // Read version from package.json
 const packageJson = JSON.parse(
@@ -187,7 +187,7 @@ const packageJson = JSON.parse(
 
 const server = new Server(
   {
-    name: "obsidian-mcp-sb",
+    name: "second-brain-mcp",
     version: packageJson.version,
   },
   {
@@ -696,7 +696,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 async function main() {
   try {
-    console.error(`Initializing Obsidian MCP Server...`);
+    console.error(`Initializing Second Brain MCP Server...`);
     console.error(`Vault path: ${resolvedVaultPath}`);
 
     await vault.initialize();
@@ -704,7 +704,7 @@ async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
 
-    console.error("Obsidian MCP Server running on stdio");
+    console.error("Second Brain MCP Server running on stdio");
   } catch (error) {
     console.error("Fatal error during initialization:");
     console.error(error instanceof Error ? error.message : String(error));

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -26,7 +26,7 @@ import { createStorage } from "./storage-factory.js";
 /**
  * Manages indexing and searching of an Obsidian vault
  */
-export class ObsidianVault {
+export class MarkdownVault {
   private storage: IStorage;
   private config: VaultConfig;
   private indexErrors: Array<{ path: string; error: string }> = [];


### PR DESCRIPTION
## Summary

- Package renamed `@comfucios/obsidian-mcp-sb` → `@comfucios/second-brain-mcp`
- Binary renamed `obsidian-mcp-sb` → `second-brain-mcp`
- `ObsidianVault` class → `MarkdownVault`
- `.obsidian-mcp/` DB dir → `.second-brain-mcp/` (existing users auto-reindex on upgrade)
- 9 Foam compatibility tests added, closes #10
- README: new Vault Compatibility section covering Obsidian, Foam, Logseq, Dendron, plain Markdown
- All docs, config examples, badge URLs, Cursor base64 config updated

## Breaking changes

- npm package name changed — existing `npx @comfucios/obsidian-mcp-sb` stops receiving updates; deprecate after merge
- `claude_desktop_config.json` / Claude Code configs need updating: `obsidian-mcp-sb` → `second-brain-mcp`
- DB cache at `.obsidian-mcp/` is ignored; vault reindexes automatically to `.second-brain-mcp/`

## Test plan

- [x] 181 tests pass
- [x] No remaining `obsidian-mcp-sb` / `ObsidianVault` / `.obsidian-mcp` references in source